### PR TITLE
Don't set log4j.configurationFile if it is a param

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>kg.apc</groupId>
     <artifactId>cmdrunner</artifactId>
-    <version>2.2</version>
+    <version>2.3</version>
     <packaging>jar</packaging>
 
     <name>Universal command-line tool runner</name>

--- a/src/kg/apc/cmd/UniversalRunner.java
+++ b/src/kg/apc/cmd/UniversalRunner.java
@@ -37,8 +37,10 @@ public final class UniversalRunner {
         URL[] urls = jars.toArray(new URL[0]);
         URLClassLoader loader = new URLClassLoader(urls);
         Thread.currentThread().setContextClassLoader(loader);
-
-        System.setProperty("log4j.configurationFile", new File(decodePath(self.getParentFile().getParent()), "bin/log4j2.xml").getAbsolutePath());
+        
+        if (System.getProperty("log4j.configurationFile") == null) {
+            System.setProperty("log4j.configurationFile", new File(decodePath(self.getParentFile().getParent()), "bin/log4j2.xml").getAbsolutePath());
+        }
     }
 
     private static String decodePath(String path) {


### PR DESCRIPTION
For maven jmeter-graph-plugin, the log4j2.xml is not find, so use log4j.configurationFile parameter and don't set it.